### PR TITLE
fix: edge cases in cd and pwd

### DIFF
--- a/srcs/exec/cd.c
+++ b/srcs/exec/cd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   cd.c                                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vbronov <vbronov@student.42lausanne.ch>    +#+  +:+       +#+        */
+/*   By: tkashi <tkashi@student.42lausanne.ch>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/17 19:07:54 by vviterbo          #+#    #+#             */
-/*   Updated: 2025/04/18 16:13:12 by vbronov          ###   ########.fr       */
+/*   Updated: 2025/04/24 04:28:19 by tkashi           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,18 @@ char	*get_absolute_path(t_data *data, char *path)
 			return (ft_error(data, "cd: memory allocation failed"), NULL);
 		return (absolute_path);
 	}
-	current_path = ft_strjoin_ip(ft_get_current_path(data), "/", FREE_S1);
+	absolute_path = ft_get_current_path(data);
+	if (absolute_path)
+		return (absolute_path);
+	ft_fprintf(STDERR_FILENO, "cd: error retrieving current directory: "
+		"getcwd: cannot access parent directories: %s\n",
+		strerror(data->exit_status));
+	data->exit_status = EXIT_SUCCESS;
+	current_path = get_var(data, "PWD");
+	if (!current_path)
+		return (ft_error(data, "cd: PWD not set"),
+			data->exit_status = EXIT_FAILURE, NULL);
+	current_path = ft_strjoin_ip(current_path, "/", FREE_S1);
 	if (!current_path)
 		return (ft_error(data, "cd: memory allocation failed"), NULL);
 	absolute_path = ft_strjoin_ip(current_path, path, FREE_S1);
@@ -65,24 +76,33 @@ static int	ft_update_oldpwd(t_data *data)
 
 	pwd = get_var(data, "PWD");
 	if (!pwd)
-		return (ft_error(data, "cd: PWD not set"), EXIT_FAILURE);
+	{
+		ft_error(data, "cd: PWD not set");
+		data->exit_status = EXIT_FAILURE;
+		return (data->exit_status);
+	}
 	pwd = ft_strjoin_ip("OLDPWD=", pwd, FREE_S2);
 	if (!pwd)
-		return (ft_error(data, "cd: memory allocation failed"), EXIT_FAILURE);
+	{
+		ft_error(data, "cd: memory allocation failed");
+		data->exit_status = EXIT_FAILURE;
+		return (data->exit_status);
+	}
 	new_var(data, pwd);
 	free(pwd);
 	return (EXIT_SUCCESS);
 }
 
-static int	ft_update_pwd(t_data *data)
+static int	ft_update_pwd(t_data *data, const char *abspath)
 {
 	char	*pwd;
 
-	pwd = ft_strjoin_ip("PWD=", ft_get_current_path(data), FREE_S2);
+	pwd = ft_strjoin("PWD=", abspath);
 	if (!pwd)
 	{
 		ft_error(data, "cd: memory allocation failed");
-		return (EXIT_FAILURE);
+		data->exit_status = EXIT_FAILURE;
+		return (data->exit_status);
 	}
 	new_var(data, pwd);
 	free(pwd);
@@ -95,25 +115,19 @@ int	ft_cd(t_data *data, char **args, int argc)
 	char	*path;
 
 	if (argc > 2)
-	{
-		ft_error(data, "cd: too many arguments");
-		return (EXIT_FAILURE);
-	}
+		return (ft_error(data, "cd: too many arguments"), EXIT_FAILURE);
 	path = handle_special_paths(data, args[1]);
 	if (!path)
-		return (EXIT_FAILURE);
+		return (data->exit_status = EXIT_FAILURE, EXIT_FAILURE);
+	if (access(path, R_OK) == -1 || chdir(path) == -1)
+	{
+		ft_fprintf(STDERR_FILENO, "%s: cd: %s: %s\n",
+			SHELL_NAME, path, strerror(errno));
+		return (free(path), data->exit_status = EXIT_FAILURE, EXIT_FAILURE);
+	}
 	abspath = get_absolute_path(data, path);
 	free(path);
-	if (data->exit_status)
-		return (EXIT_FAILURE);
-	if (access(abspath, R_OK) == -1 || chdir(abspath) == -1)
-	{
-		ft_error(data, "cd");
-		free(abspath);
-		return (EXIT_FAILURE);
-	}
-	free(abspath);
-	if (ft_update_oldpwd(data) || ft_update_pwd(data))
-		return (EXIT_FAILURE);
-	return (EXIT_SUCCESS);
+	if (ft_update_oldpwd(data) || ft_update_pwd(data, abspath))
+		return (free(abspath), EXIT_FAILURE);
+	return (free(abspath), EXIT_SUCCESS);
 }

--- a/srcs/exec/pwd.c
+++ b/srcs/exec/pwd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pwd.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vviterbo <vviterbo@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tkashi <tkashi@student.42lausanne.ch>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/17 22:22:20 by vviterbo          #+#    #+#             */
-/*   Updated: 2025/04/07 13:47:57 by vviterbo         ###   ########.fr       */
+/*   Updated: 2025/04/24 04:38:24 by tkashi           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,15 +17,18 @@ int	ft_pwd(t_data *data, char **args, int argc)
 	char	*current_path;
 	size_t	printed;
 
-	if (argc > 1)
-	{
-		ft_error(data, "pwd: too many arguments");
-		return (EXIT_FAILURE);
-	}
 	(void)args;
+	if (argc > 1)
+		return (ft_error(data, "pwd: too many arguments"),EXIT_FAILURE);
 	current_path = ft_get_current_path(data);
-	if (data->exit_status)
-		return (EXIT_FAILURE);
+	if (!current_path)
+	{
+		data->exit_status = EXIT_SUCCESS;
+		current_path = get_var(data, "PWD");
+		if (!current_path)
+			return (ft_error(data, "pwd: PWD not set"),
+				data->exit_status = EXIT_FAILURE, EXIT_FAILURE);
+	}
 	printed = ft_printf("%s\n", current_path);
 	if (printed != ft_strlen(current_path) + 1)
 	{
@@ -40,25 +43,21 @@ int	ft_pwd(t_data *data, char **args, int argc)
 char	*ft_get_current_path(t_data *data)
 {
 	char	*current_path;
-	int		attempts;
+	int		attempt;
 	char	*retvalue;
 
-	attempts = 1;
-	current_path = ft_calloc(PATH_MAX + 1, sizeof(char));
-	if (!current_path)
-		return (ft_error(data, "pwd: memory allocation failed"), NULL);
-	retvalue = getcwd(current_path, PATH_MAX * attempts);
-	while (attempts < 3 && retvalue == NULL && errno == ERANGE)
+	retvalue = NULL;
+	attempt = 1;
+	while ((attempt <= 2 && data->exit_status == ERANGE) || attempt == 1)
 	{
-		attempts++;
-		free(current_path);
-		current_path = ft_calloc(PATH_MAX * attempts + 1, sizeof(char));
+		current_path = ft_calloc(PATH_MAX * attempt + 1, sizeof(char));
 		if (!current_path)
-			return (ft_error(data, "pwd: memory allocation failed"), NULL);
-		retvalue = getcwd(current_path, PATH_MAX * attempts);
+			return (data->exit_status = errno, NULL);
+		retvalue = getcwd(current_path, PATH_MAX * attempt);
+		data->exit_status = errno;
+		if (!retvalue)
+			free(current_path);
+		attempt++;
 	}
-	if (retvalue == NULL)
-		return (free(current_path),
-			ft_error(data, "pwd: could not load path"), NULL);
-	return (current_path);
+	return (retvalue);
 }

--- a/srcs/minishell.c
+++ b/srcs/minishell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vbronov <vbronov@student.42lausanne.ch>    +#+  +:+       +#+        */
+/*   By: tkashi <tkashi@student.42lausanne.ch>      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/03 08:35:11 by vviterbo          #+#    #+#             */
-/*   Updated: 2025/04/20 01:38:48 by vbronov          ###   ########.fr       */
+/*   Updated: 2025/04/24 03:00:23 by tkashi           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,13 +16,13 @@ enum e_signal	g_signal;
 
 /**
  * @brief Handles incoming signals for minishell
- * 
+ *
  * SIGINT: CTRL+C, SIGQUIT: CTRL+\ and CTRL+D (EOF) are handled
  * acording to the current mode of the shell,
  * either interactive (READLINE_MODE) or execution (EXECUTION_MODE).
- * 
+ *
  * @param signum The signal number to be handled
- * 
+ *
  * @return void
  */
 void	signal_handler(int signum)
@@ -53,11 +53,11 @@ static int	init_data(t_data *data, char **envp)
 
 static void	process_line(t_data *data, char *line)
 {
-	data->last_exit_status = data->exit_status;
-	data->exit_status = EXIT_SUCCESS;
 	lexer(data, line);
 	if (data->tokens)
 	{
+		data->last_exit_status = data->exit_status;
+		data->exit_status = EXIT_SUCCESS;
 		add_history(line);
 		if (DEBUG)
 			print_tokens(data->tokens);

--- a/test minishell to fix.txt
+++ b/test minishell to fix.txt
@@ -1,0 +1,37 @@
+test minishell  to fix: (echo with dollars and dot)
+
+
+$ echo $HOME
+$ echo $HOMEsdjhfk$HOME
+$ echo $HOME.sdjhfk$HOME
+
+"."
+
+bash : 
+bash: .: filename argument required
+.: usage: . filename [arguments]
+
+minishell :
+
+minishell: /usr/local/sbin/.: Permission denied
+
+echo $
+
+
+cat >$x
+
+<file1
+
+
+(differnce between open: and file1: no such file)
+
+
+minishell$ pwd
+/home/csa
+minishell$ mkdir test
+minishell$ cd test/
+minishell$ rm -rf ../test
+minishell$ cd .
+
+
+


### PR DESCRIPTION
fix for edge cases:

csa@csa-Precision-5560:~/Documents/taltol/junk/victor_minishell$ mkdir test
csa@csa-Precision-5560:~/Documents/taltol/junk/victor_minishell$ cd test/
csa@csa-Precision-5560:~/Documents/taltol/junk/victor_minishell/test$ rm -rf ../test
csa@csa-Precision-5560:~/Documents/taltol/junk/victor_minishell/test$ cd .
cd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory

csa@csa-Precision-5560:~/Documents/taltol/junk/victor_minishell$ ./bin/minishell 
minishell$ mkdir test
minishell$ cd test
minishell$ rm -rf ../test
minishell$ cd .
minishell: pwd: could not load path: No such file or directory
minishell: cd: memory allocation failed: No such file or directory

additional cases were we try to pwd from unexisting folder or jump to unexisting folder either directly or by ../ or by "cd -"